### PR TITLE
Use new template format for templates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,18 @@ Configuration > [Integrations](https://my.home-assistant.io/redirect/integration
 Configuration > [Integrations](https://my.home-assistant.io/redirect/integrations/) > **Prijsplafond** > Configure
 
 ### Useful template examples:
-```
-- platform: template
-  sensors: 
-
-    # Template sensor to display the current monthly cap.
-    prijsplafond_monthly_gas_cap:
-      friendly_name: "Prijsplafond this month gas cap"
-      unit_of_measurement: "m³"
-      value_template: "{{ state_attr('sensor.prijsplafond_gas', 'this_month_cap') }}"
-
-    # Template sensor to display what this month total costs are.
-    prijsplafond_this_month_costs:
-      friendly_name: "Prijsplafond total costs this month"
-      unit_of_measurement: "EUR"
-      value_template: "..TODO.."
+```yaml
+template:
+  - sensor:
+      # Template sensor to display the current monthly cap.
+      - unique_id: sensor_prijsplafond_monthly_gas_cap
+        name: Prijsplafond Monthly Gas Cap
+        state: "{{ state_attr('sensor.prijsplafond_gas', 'this_month_cap') }}"
+        unit_of_measurement:  "m³"
+        
+      # Template sensor to display what this month total costs are.
+      - unique_id: sensor_prijsplafond_this_month_costs
+        name: Prijsplafond Thijs Month Costs
+        state: "{{ TO DO }}"
+        unit_of_measurement: "EUR"
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ template:
         
       # Template sensor to display what this month total costs are.
       - unique_id: sensor_prijsplafond_this_month_costs
-        name: Prijsplafond Thijs Month Costs
+        name: Prijsplafond This Month Costs
         state: "{{ TO DO }}"
         unit_of_measurement: "EUR"
 ```


### PR DESCRIPTION
Noticed that you are using the legacy format. I've converted them to the new template sensor format